### PR TITLE
Add feature: alternative lock icon

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -1,7 +1,7 @@
 <script type="text/discourse-plugin" version="0.8">
   const { h } = require('virtual-dom');
   const { iconNode } = require("discourse-common/lib/icon-library");
-  let lockIcon = iconNode('unlock-alt');
+  let lockIcon = settings.category_lock_icon || "lock";
 
   api.createWidget('category-header-widget', {
       tagName: 'span',

--- a/common/header.html
+++ b/common/header.html
@@ -1,7 +1,7 @@
 <script type="text/discourse-plugin" version="0.8">
   const { h } = require('virtual-dom');
   const { iconNode } = require("discourse-common/lib/icon-library");
-  let lockIcon = settings.category_lock_icon || "lock";
+  let lockIcon = iconNode(settings.category_lock_icon);  || iconNode('lock');
 
   api.createWidget('category-header-widget', {
       tagName: 'span',

--- a/common/header.html
+++ b/common/header.html
@@ -1,7 +1,8 @@
 <script type="text/discourse-plugin" version="0.8">
   const { h } = require('virtual-dom');
   const { iconNode } = require("discourse-common/lib/icon-library");
-  let lockIcon = iconNode(settings.category_lock_icon);  || iconNode('lock');
+  let iconName = settings.category_lock_icon || 'lock'; // Fallback to 'lock' if setting is not defined
+  let lockIcon = iconNode(iconName);
 
   api.createWidget('category-header-widget', {
       tagName: 'span',

--- a/settings.yml
+++ b/settings.yml
@@ -36,7 +36,11 @@ show_parent_category_name:
   type: bool
   default: true
   description: 'Prefix the parent category name on the subcategory headers'   
-  
+
+category_lock_icon:
+  default: ""
+  description: 'Enter the name of a FontAwesome 5 icon to display instead of the lock icon next to private categories'
+
 show_lock_icon:
   type: bool
   default: true


### PR DESCRIPTION
This adds compatibility with the alternative lock icon functionality in https://github.com/discourse/discourse-category-icons

I didn't add an icon specifier, as it is only intended for use with the other TC (which will do the specifying already).