### PR TITLE
Add customizable "Read more" link to category headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ The default core Discourse category header is displayed on the category page abo
 
 ## This theme component provides the following enhancements
 
-### This theme component provides the following enhancements
-
 ### Theme settings
 
 * <b>show category name:</b> Show the category name in the header
@@ -37,6 +35,15 @@ The default core Discourse category header is displayed on the category page abo
 * <b>force mobile alignment:</b> Force mobile alignment of logo-text to the top-centre of the header
 * <b>hide if no category description:</b> Hide header if category description is not set
 * <b>hide category exceptions:</b> Headers will not show for these categories
+* <b>show read more link:</b> Show a "Read more" link at the bottom of the category header
+* <b>read more link text:</b> Customize the text for the "Read more" link
+
+### New Features
+
+* <b>Read More Link:</b> An optional "Read more" link can now be added to the bottom of the category header. This link directs users to the full "About this category" topic.
+* <b>Customizable Link Text:</b> The text for the "Read more" link can be customized to suit your community's needs.
+
+These new features provide more flexibility in guiding users to additional category information and can be easily toggled on or off through the theme settings.
 
 For further information, please see the instructions and screenshots on Discourse Meta.
 https://meta.discourse.org/t/discourse-category-headers-theme-component/148682

--- a/common/common.scss
+++ b/common/common.scss
@@ -117,12 +117,13 @@ div[class^="category-title-header"] {
     display: inline-block;
 }
 
+.category-about-url {
+  margin-top: 10px;
+  padding: 0 20px 20px; // Add padding to match the rest of the component
+  text-align: left;
+}
 
-  .category-about-url {
-    margin-top: 10px;
-    text-align: left;
-  }
-  .category-about-url a {
-    color: inherit;
-    text-decoration: none;
-  }
+// Remove the color override to use the default link color
+.category-about-url a {
+  text-decoration: none;
+}

--- a/common/common.scss
+++ b/common/common.scss
@@ -116,3 +116,20 @@ div[class^="category-title-header"] {
     height: auto;       
     display: inline-block;
 }
+
+
+  .category-about-url {
+    margin-top: 10px;
+    font-size: 0.9em;
+    text-align: right;
+  }
+  .category-about-url a {
+    color: inherit;
+    text-decoration: underline;
+    padding: 5px 10px;  /* Added padding */
+    display: inline-block;  /* This ensures the padding is applied properly */
+  }
+  .category-about-url a:hover {
+    background-color: rgba(0, 0, 0, 0.05);  /* Optional: adds a subtle background on hover */
+    border-radius: 3px;  /* Optional: rounds the corners of the hover effect */
+  }

--- a/common/common.scss
+++ b/common/common.scss
@@ -117,10 +117,21 @@ div[class^="category-title-header"] {
     display: inline-block;
 }
 
+// Update the category-about-url rules
 .category-about-url {
   margin-top: 10px;
   padding: 0 20px 20px; // Add padding to match the rest of the component
   text-align: left;
+
+  @if($description_text_size == "smaller"){
+    font-size: $font-down-1;
+  } @else if($description_text_size == "normal"){
+    font-size: $font-0;
+  } @else if($description_text_size == "larger"){
+    font-size: $font-up-1;
+  } @else if($description_text_size == "largest") {
+    font-size: $font-up-2;          
+  }
 }
 
 // Remove the color override to use the default link color

--- a/common/common.scss
+++ b/common/common.scss
@@ -120,16 +120,9 @@ div[class^="category-title-header"] {
 
   .category-about-url {
     margin-top: 10px;
-    font-size: 0.9em;
-    text-align: right;
+    text-align: left;
   }
   .category-about-url a {
     color: inherit;
-    text-decoration: underline;
-    padding: 5px 10px;  /* Added padding */
-    display: inline-block;  /* This ensures the padding is applied properly */
-  }
-  .category-about-url a:hover {
-    background-color: rgba(0, 0, 0, 0.05);  /* Optional: adds a subtle background on hover */
-    border-radius: 3px;  /* Optional: rounds the corners of the hover effect */
+    text-decoration: none;
   }

--- a/common/header.html
+++ b/common/header.html
@@ -77,9 +77,9 @@
                   }
                   
                   function aboutTopicUrl() {
-                    if (category.topic_url) {
+                    if (settings.show_read_more_link && category.topic_url) {
                       return h('div.category-about-url', [
-                        h('a', { "attributes": { "href": category.topic_url } }, "Read more about this category…")
+                        h('a', { "attributes": { "href": category.topic_url } }, settings.read_more_link_text)
                       ]);
                     }
                   }

--- a/common/header.html
+++ b/common/header.html
@@ -76,21 +76,31 @@
                       return headerStyle;
                   }
                   
+                  function aboutTopicUrl() {
+                    if (category.topic_url) {
+                      return h('div.category-about-url', [
+                        h('a', { "attributes": { "href": category.topic_url } }, "About this category")
+                      ]);
+                    }
+                  }
+                  
                   return h('div.category-title-header' + " .category-banner-" + category.slug, {
                       "attributes" : {
                           "style" : getHeaderStyle()
                       }
-                  }, h('div.category-title-contents', [ 
-                  h('div.category-logo.aspect-image', logoImg()), 
-                  h('div.category-title-name', [
-                  ifParentProtected(),                      
-                  ifParentCategory(),                      
-                  ifProtected(),
-                  h('h1', category.name)
-                  ]),
-                  h('div.category-title-description',catDesc())
-                  ]),
-                  );
+                  }, [
+                    h('div.category-title-contents', [ 
+                      h('div.category-logo.aspect-image', logoImg()), 
+                      h('div.category-title-name', [
+                        ifParentProtected(),                      
+                        ifParentCategory(),                      
+                        ifProtected(),
+                        h('h1', category.name)
+                      ]),
+                      h('div.category-title-description', catDesc())
+                    ]),
+                    aboutTopicUrl()
+                  ]);
               }
           } else {
               $("body").removeClass("category-header");
@@ -111,3 +121,15 @@
 >
   {{mount-widget widget="category-header-widget"}}
 </script>
+
+<style>
+  .category-about-url {
+    margin-top: 10px;
+    font-size: 0.9em;
+    text-align: right;
+  }
+  .category-about-url a {
+    color: inherit;
+    text-decoration: underline;
+  }
+</style>

--- a/common/header.html
+++ b/common/header.html
@@ -79,7 +79,7 @@
                   function aboutTopicUrl() {
                     if (category.topic_url) {
                       return h('div.category-about-url', [
-                        h('a', { "attributes": { "href": category.topic_url } }, "About this category")
+                        h('a', { "attributes": { "href": category.topic_url } }, "Read more about this category…")
                       ]);
                     }
                   }
@@ -125,11 +125,10 @@
 <style>
   .category-about-url {
     margin-top: 10px;
-    font-size: 0.9em;
-    text-align: right;
+    text-align: left;
   }
   .category-about-url a {
     color: inherit;
-    text-decoration: underline;
+    text-decoration: none;
   }
 </style>

--- a/common/header.html
+++ b/common/header.html
@@ -121,14 +121,3 @@
 >
   {{mount-widget widget="category-header-widget"}}
 </script>
-
-<style>
-  .category-about-url {
-    margin-top: 10px;
-    text-align: left;
-  }
-  .category-about-url a {
-    color: inherit;
-    text-decoration: none;
-  }
-</style>

--- a/settings.yml
+++ b/settings.yml
@@ -120,5 +120,14 @@ hide_category_exceptions:
   default: '' 
   description: 'Headers will not show for these categories'
 
+show_read_more_link:
+  type: bool
+  default: true
+  description: 'Show the "Read more" link at the bottom of the category header'
+
+read_more_link_text:
+  type: string
+  default: 'Read more about this category…'
+  description: 'Custom text for the "Read more" link'
 
 


### PR DESCRIPTION
This PR adds a new optional feature to the category headers:
- Introduces a "Read more" link at the bottom of category headers
- Adds two new theme settings:
  1. Toggle to show/hide the link
  2. Text field to customize the link text
- Link directs users to the full "About this category" topic
