### PR TITLE
Add '@service site' to category-header.gjs

### DIFF
--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -5,6 +5,7 @@ import icon from "discourse/helpers/d-icon";
 
 export default class CategoryHeader extends Component {
   @service siteSettings;
+  @service site;
 
   get ifParentCategory() {
     if (this.args.category.parentCategory) {


### PR DESCRIPTION
With this PR, `@service site;` is added to category-header.gjs, to fix the error of `this.site.mobileView` being `undefined`.