### PR TITLE
Add 'smallest' option to category description text size

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -59,7 +59,7 @@ div[class^="category-title-header"] {
     padding-top: 0.5em;
 
     @if $description_text_size == "smallest" {
-      font-size: $font-up-0;
+      font-size: $font-0;
     } @else if $description_text_size == "smaller" {
       font-size: $font-up-2
     } @else if $description_text_size == "normal" {

--- a/common/common.scss
+++ b/common/common.scss
@@ -59,7 +59,7 @@ div[class^="category-title-header"] {
     padding-top: 0.5em;
 
     @if $description_text_size == "smallest" {
-      font-size: $font-up-1;
+      font-size: $font-up-0;
     } @else if $description_text_size == "smaller" {
       font-size: $font-up-2
     } @else if $description_text_size == "normal" {

--- a/common/common.scss
+++ b/common/common.scss
@@ -58,8 +58,10 @@ div[class^="category-title-header"] {
   .category-title-description {
     padding-top: 0.5em;
 
-    @if $description_text_size == "smaller" {
-      font-size: $font-up-2;
+    @if $description_text_size == "smallest" {
+      font-size: $font-up-1;
+    } @else if $description_text_size == "smaller" {
+      font-size: $font-up-2
     } @else if $description_text_size == "normal" {
       font-size: $font-up-3;
     } @else if $description_text_size == "larger" {

--- a/common/common.scss
+++ b/common/common.scss
@@ -61,7 +61,7 @@ div[class^="category-title-header"] {
     @if $description_text_size == "smallest" {
       font-size: $font-0;
     } @else if $description_text_size == "smaller" {
-      font-size: $font-up-2
+      font-size: $font-up-2;
     } @else if $description_text_size == "normal" {
       font-size: $font-up-3;
     } @else if $description_text_size == "larger" {

--- a/settings.yml
+++ b/settings.yml
@@ -12,6 +12,7 @@ description_text_size:
   type: enum
   default: larger  
   choices:
+  - smallest
   - smaller
   - normal
   - larger    


### PR DESCRIPTION
This PR adds an option to the setting `description_text_size`, `smallest`, which has the corresponding CSS text size of `$font-0`.