### PR TITLE
FIX: Fix lock icon & remove padding if no category logos

### DIFF
--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -66,7 +66,6 @@ export default class CategoryHeader extends Component {
   }
 
   get ifParentProtected() {
-    console.log(this.args.category);
     if (
       this.args.category.parentCategory &&
       (


### PR DESCRIPTION
This PR adds the `if` check if a category is restricted, from using `read_restricted` to using `permission` as well, to display the lock icon.

Additionally, if there is no category icon or site logo, it will remove the padding on the category title on the right to not indent the title.