### PR TITLE
FIX: Hide lock icon with parent category name

### DIFF
--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -177,10 +177,10 @@ export default class CategoryHeader extends Component {
             </div>
           {{/if}}
           <div class="category-title-name" style={{if (not (this.logoImg)) "padding: 0 !important;"}}>
-            {{#if this.ifParentProtected}}
-              {{icon this.lockIcon}}
-            {{/if}}
             {{#if this.ifParentCategory}}
+              {{#if this.ifParentProtected}}
+                {{icon this.lockIcon}}
+              {{/if}}
               <a class="parent-box-link" href={{@category.parentCategory.url}}>
                 <h1>{{@category.parentCategory.name}}: </h1>
               </a>

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -178,10 +178,10 @@ export default class CategoryHeader extends Component {
           {{/if}}
           <div class="category-title-name" style={{if (not (this.logoImg)) "padding: 0 !important;"}}>
             {{#if this.ifParentCategory}}
-              {{#if this.ifParentProtected}}
-                {{icon this.lockIcon}}
-              {{/if}}
               <a class="parent-box-link" href={{@category.parentCategory.url}}>
+                {{#if this.ifParentProtected}}
+                  {{icon this.lockIcon}}
+                {{/if}}
                 <h1>{{@category.parentCategory.name}}: </h1>
               </a>
             {{/if}}


### PR DESCRIPTION
If `show_parent_category_name` is disabled, the sub-category name would have 2 lock icons instead of 1. This places the parent category's lock icon within the parent category name.