### PR TITLE
Support dark mode category logos

### DIFF
--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -193,16 +193,16 @@ export default class CategoryHeader extends Component {
         <div class="category-title-contents">
           {{this.logoImg.url}}
           {{this.darkLogoImg.url}}
+          <!--
           {{#if this.logoImg}}
             <div class="category-logo aspect-image">
-              <!--
-                <LightDarkImg
-                  @lightImg={{this.logoImg}}
-                  @darkImg={{this.darkLogoImg}}
-                />
-              -->
+              <LightDarkImg
+                @lightImg={{this.logoImg}}
+                @darkImg={{this.darkLogoImg}}
+              />
             </div>
           {{/if}}
+          -->
           <div class="category-title-name" style={{if (not (this.logoImg)) "padding: 0 !important;"}}>
             {{#if this.ifParentCategory}}
               <a class="parent-box-link" href={{@category.parentCategory.url}}>

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -3,7 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 
-import LightDarkImg from "./light-dark-img";
+import LightDarkImg from "discourse/components/light-dark-img";
 import { ajax } from "discourse/lib/ajax";
 import icon from "discourse/helpers/d-icon";
 

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -191,12 +191,16 @@ export default class CategoryHeader extends Component {
         style={{this.getHeaderStyle}}
       >
         <div class="category-title-contents">
+          {{this.logoImg.url}}
+          {{this.darkLogoImg.url}}
           {{#if (and this.logoImg this.darkLogoImg)}}
             <div class="category-logo aspect-image">
-              <LightDarkImg
-                @lightImg={{this.logoImg}}
-                @darkImg={{this.darkLogoImg}}
-              />
+              <!--
+                <LightDarkImg
+                  @lightImg={{this.logoImg}}
+                  @darkImg={{this.darkLogoImg}}
+                />
+              -->
             </div>
           {{/if}}
           <div class="category-title-name" style={{if (not (this.logoImg)) "padding: 0 !important;"}}>

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -191,6 +191,8 @@ export default class CategoryHeader extends Component {
         style={{this.getHeaderStyle}}
       >
         <div class="category-title-contents">
+          {{this.logoImg}}
+          {{this.darkLogoImg}}
           {{#if (or this.logoImg this.darkLogoImg)}}
             <div class="category-logo aspect-image">
               <LightDarkImg

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -191,12 +191,8 @@ export default class CategoryHeader extends Component {
         style={{this.getHeaderStyle}}
       >
         <div class="category-title-contents">
-          {{this.logoImg}}
-          {{this.darkLogoImg}}
           {{#if (or this.logoImg this.darkLogoImg)}}
             <div class="category-logo aspect-image">
-              <img src={{this.logoImg}} />
-              <img src={{this.darkLogoImg}} />
               <LightDarkImg
                 @lightImg={{this.logoImg}}
                 @darkImg={{this.darkLogoImg}}

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -195,6 +195,8 @@ export default class CategoryHeader extends Component {
           {{this.darkLogoImg}}
           {{#if (or this.logoImg this.darkLogoImg)}}
             <div class="category-logo aspect-image">
+              <img src={{this.logoImg}} />
+              <img src={{this.darkLogoImg}} />
               <LightDarkImg
                 @lightImg={{this.logoImg}}
                 @darkImg={{this.darkLogoImg}}

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -203,7 +203,10 @@ export default class CategoryHeader extends Component {
             </div>
           {{/if}}
           -->
-          <div class="category-title-name" <!--style={{if (not (this.logoImg)) "padding: 0 !important;"}}-->>
+          <!--
+          <div class="category-title-name" style={{if (not (this.logoImg)) "padding: 0 !important;"}}>
+          -->
+          <div class="category-title-name" style={{if (this.logoImg)) "padding: 0 !important;"}}>
             {{#if this.ifParentCategory}}
               <a class="parent-box-link" href={{@category.parentCategory.url}}>
                 {{#if this.ifParentProtected}}
@@ -213,7 +216,7 @@ export default class CategoryHeader extends Component {
               </a>
             {{/if}}
             {{#if this.ifProtected}}
-              <!--{{icon this.lockIcon}}-->
+              <!-- {{icon this.lockIcon}} -->
             {{/if}}
             <h1>{{@category.name}}</h1>
           </div>

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -51,7 +51,6 @@ export default class CategoryHeader extends Component {
 
   get logoImg() {
     if (settings.show_category_logo && this.args.category.uploaded_logo) {
-      console.log(this.args.category.uploaded_logo.url);
       return this.args.category.uploaded_logo;
     } else if (
       settings.show_category_logo &&
@@ -59,23 +58,18 @@ export default class CategoryHeader extends Component {
       this.args.category.parentCategory &&
       this.args.category.parentCategory.uploaded_logo
     ) {
-      console.log(2);
       return this.args.category.parentCategory.uploaded_logo;
     } else if (settings.show_site_logo && this.siteSettings.logo_small) {
-      console.log(3);
-      console.log(this.siteSettings.logo_small);
       let map = {};
       map['url'] = this.siteSettings.logo_small
       return map;
     } else {
-      console.log(4);
       return false;
     }
   }
 
   get darkLogoImg() {
     if (settings.show_dark_mode_category_logo && this.args.category.uploaded_logo_dark) {
-      console.log(this.args.category.uploaded_logo_dark.url);
       return this.args.category.uploaded_logo_dark;
     } else if (
       settings.show_dark_mode_category_logo &&
@@ -83,16 +77,12 @@ export default class CategoryHeader extends Component {
       this.args.category.parentCategory &&
       this.args.category.parentCategory.uploaded_logo_dark
     ) {
-      console.log(22);
       return this.args.category.parentCategory.uploaded_logo_dark;
     } else if (settings.show_site_logo && this.siteSettings.logo_small) {
-      console.log(33);
-      console.log(this.siteSettings.logo_small);
       let map = {};
       map['url'] = this.siteSettings.logo_small
       return map;
     } else {
-      console.log(44);
       return this.args.category.uploaded_logo; // If no dark mode logo is uploaded, use the normal logo
     } 
   }
@@ -203,8 +193,6 @@ export default class CategoryHeader extends Component {
         style={{this.getHeaderStyle}}
       >
         <div class="category-title-contents">
-          {{this.logoImg.url}}
-          {{this.darkLogoImg.url}}
           {{#if (and this.logoImg this.darkLogoImg)}}
             <div class="category-logo aspect-image">
               <LightDarkImg

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -7,7 +7,7 @@ import LightDarkImg from "discourse/components/light-dark-img";
 import { ajax } from "discourse/lib/ajax";
 import icon from "discourse/helpers/d-icon";
 
-import { and, not } from "truth-helpers";
+import { not } from "truth-helpers";
 
 export default class CategoryHeader extends Component {
   @service siteSettings;

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -203,7 +203,7 @@ export default class CategoryHeader extends Component {
             </div>
           {{/if}}
           -->
-          <div class="category-title-name" style={{!if (not (this.logoImg)) "padding: 0 !important;"}}>
+          <div class="category-title-name" <!--style={{if (not (this.logoImg)) "padding: 0 !important;"}}-->>
             {{#if this.ifParentCategory}}
               <a class="parent-box-link" href={{@category.parentCategory.url}}>
                 {{#if this.ifParentProtected}}
@@ -213,7 +213,7 @@ export default class CategoryHeader extends Component {
               </a>
             {{/if}}
             {{#if this.ifProtected}}
-              {{!icon this.lockIcon}}
+              <!--{{icon this.lockIcon}}-->
             {{/if}}
             <h1>{{@category.name}}</h1>
           </div>

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -51,6 +51,7 @@ export default class CategoryHeader extends Component {
 
   get logoImg() {
     if (settings.show_category_logo && this.args.category.uploaded_logo) {
+      console.log(this.args.category.uploaded_logo.url);
       return this.args.category.uploaded_logo.url;
     } else if (
       settings.show_category_logo &&
@@ -68,7 +69,8 @@ export default class CategoryHeader extends Component {
 
   get darkLogoImg() {
     if (settings.show_dark_mode_category_logo && this.args.category.uploaded_logo_dark.url) {
-      return this.args.category.uploaded_logo.url;
+      console.log(this.args.category.uploaded_logo_dark.url);
+      return this.args.category.uploaded_logo_dark.url;
     } else if (
       settings.show_dark_mode_category_logo &&
       settings.show_parent_category_dark_mode_logo &&

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -193,7 +193,7 @@ export default class CategoryHeader extends Component {
         <div class="category-title-contents">
           {{this.logoImg.url}}
           {{this.darkLogoImg.url}}
-          {{#if (and this.logoImg this.darkLogoImg)}}
+          {{#if this.logoImg}}
             <div class="category-logo aspect-image">
               <!--
                 <LightDarkImg

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -3,7 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 
-import LightDarkImg from "light-dark-img";
+import LightDarkImg from "./light-dark-img";
 import { ajax } from "discourse/lib/ajax";
 import icon from "discourse/helpers/d-icon";
 

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -5,9 +5,9 @@ import { htmlSafe } from "@ember/template";
 
 import LightDarkImg from "discourse/components/light-dark-img";
 import { ajax } from "discourse/lib/ajax";
-import icon from "discourse/helpers/d-icon";
+// import icon from "discourse/helpers/d-icon";
 
-import { not } from "truth-helpers";
+// import { not } from "truth-helpers";
 
 export default class CategoryHeader extends Component {
   @service siteSettings;
@@ -203,7 +203,7 @@ export default class CategoryHeader extends Component {
             </div>
           {{/if}}
           -->
-          <div class="category-title-name" style={{if (not (this.logoImg)) "padding: 0 !important;"}}>
+          <div class="category-title-name" style={{!if (not (this.logoImg)) "padding: 0 !important;"}}>
             {{#if this.ifParentCategory}}
               <a class="parent-box-link" href={{@category.parentCategory.url}}>
                 {{#if this.ifParentProtected}}
@@ -213,7 +213,7 @@ export default class CategoryHeader extends Component {
               </a>
             {{/if}}
             {{#if this.ifProtected}}
-              {{icon this.lockIcon}}
+              {{!icon this.lockIcon}}
             {{/if}}
             <h1>{{@category.name}}</h1>
           </div>

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -59,10 +59,13 @@ export default class CategoryHeader extends Component {
       this.args.category.parentCategory &&
       this.args.category.parentCategory.uploaded_logo
     ) {
+      console.log(2);
       return this.args.category.parentCategory.uploaded_logo;
     } else if (settings.show_site_logo && this.siteSettings.logo_small) {
+      console.log(3);
       return this.siteSettings.logo_small;
     } else {
+      console.log(4);
       return false;
     }
   }
@@ -77,10 +80,13 @@ export default class CategoryHeader extends Component {
       this.args.category.parentCategory &&
       this.args.category.parentCategory.uploaded_logo_dark
     ) {
+      console.log(22);
       return this.args.category.parentCategory.uploaded_logo_dark;
     } else if (settings.show_site_logo && this.siteSettings.logo_small) {
+      console.log(33);
       return this.siteSettings.logo_small;
     } else {
+      console.log(44);
       return this.args.category.uploaded_logo; // If no dark mode logo is uploaded, use the normal logo
     } 
   }

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 
+import LightDarkImg from "discourse/components/light-dark-img";
 import { ajax } from "discourse/lib/ajax";
 import icon from "discourse/helpers/d-icon";
 

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -5,9 +5,9 @@ import { htmlSafe } from "@ember/template";
 
 import LightDarkImg from "discourse/components/light-dark-img";
 import { ajax } from "discourse/lib/ajax";
-// import icon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 
-// import { not } from "truth-helpers";
+import { and, not } from "truth-helpers";
 
 export default class CategoryHeader extends Component {
   @service siteSettings;
@@ -193,8 +193,7 @@ export default class CategoryHeader extends Component {
         <div class="category-title-contents">
           {{this.logoImg.url}}
           {{this.darkLogoImg.url}}
-          <!--
-          {{#if this.logoImg}}
+          {{#if (and this.logoImg this.darkLogoImg)}}
             <div class="category-logo aspect-image">
               <LightDarkImg
                 @lightImg={{this.logoImg}}
@@ -202,11 +201,7 @@ export default class CategoryHeader extends Component {
               />
             </div>
           {{/if}}
-          -->
-          <!--
-          <div class="category-title-name" style={{if (not (this.logoImg)) "padding: 0 !important;"}}>
-          -->
-          <div class="category-title-name" style={{if (this.logoImg)) "padding: 0 !important;"}}>
+          <div class="category-title-name" style={{if (not this.logoImg) "padding: 0 !important;"}}>
             {{#if this.ifParentCategory}}
               <a class="parent-box-link" href={{@category.parentCategory.url}}>
                 {{#if this.ifParentProtected}}
@@ -216,7 +211,7 @@ export default class CategoryHeader extends Component {
               </a>
             {{/if}}
             {{#if this.ifProtected}}
-              <!-- {{icon this.lockIcon}} -->
+              {{icon this.lockIcon}}
             {{/if}}
             <h1>{{@category.name}}</h1>
           </div>

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -65,7 +65,7 @@ export default class CategoryHeader extends Component {
       console.log(3);
       console.log(this.siteSettings.logo_small);
       let map = {};
-      map[url] = this.siteSettings.logo_small
+      map['url'] = this.siteSettings.logo_small
       return map;
     } else {
       console.log(4);
@@ -89,7 +89,7 @@ export default class CategoryHeader extends Component {
       console.log(33);
       console.log(this.siteSettings.logo_small);
       let map = {};
-      map[url] = this.siteSettings.logo_small
+      map['url'] = this.siteSettings.logo_small
       return map;
     } else {
       console.log(44);

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -7,7 +7,7 @@ import LightDarkImg from "./light-dark-img";
 import { ajax } from "discourse/lib/ajax";
 import icon from "discourse/helpers/d-icon";
 
-import { or, not } from "truth-helpers";
+import { and, not } from "truth-helpers";
 
 export default class CategoryHeader extends Component {
   @service siteSettings;
@@ -191,7 +191,7 @@ export default class CategoryHeader extends Component {
         style={{this.getHeaderStyle}}
       >
         <div class="category-title-contents">
-          {{#if (or this.logoImg this.darkLogoImg)}}
+          {{#if (and this.logoImg this.darkLogoImg)}}
             <div class="category-logo aspect-image">
               <LightDarkImg
                 @lightImg={{this.logoImg}}

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -73,7 +73,7 @@ export default class CategoryHeader extends Component {
       return this.args.category.uploaded_logo_dark;
     } else if (
       settings.show_dark_mode_category_logo &&
-      settings.show_parent_category_dark_mode_logo &&
+      settings.show_dark_mode_parent_category_logo &&
       this.args.category.parentCategory &&
       this.args.category.parentCategory.uploaded_logo_dark
     ) {

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -63,6 +63,7 @@ export default class CategoryHeader extends Component {
       return this.args.category.parentCategory.uploaded_logo;
     } else if (settings.show_site_logo && this.siteSettings.logo_small) {
       console.log(3);
+      console.log(this.siteSettings.logo_small);
       return this.siteSettings.logo_small;
     } else {
       console.log(4);
@@ -84,6 +85,7 @@ export default class CategoryHeader extends Component {
       return this.args.category.parentCategory.uploaded_logo_dark;
     } else if (settings.show_site_logo && this.siteSettings.logo_small) {
       console.log(33);
+      console.log(this.siteSettings.logo_small);
       return this.siteSettings.logo_small;
     } else {
       console.log(44);

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -64,7 +64,9 @@ export default class CategoryHeader extends Component {
     } else if (settings.show_site_logo && this.siteSettings.logo_small) {
       console.log(3);
       console.log(this.siteSettings.logo_small);
-      return this.siteSettings.logo_small;
+      let map = {};
+      map[url] = this.siteSettings.logo_small
+      return map;
     } else {
       console.log(4);
       return false;
@@ -86,7 +88,9 @@ export default class CategoryHeader extends Component {
     } else if (settings.show_site_logo && this.siteSettings.logo_small) {
       console.log(33);
       console.log(this.siteSettings.logo_small);
-      return this.siteSettings.logo_small;
+      let map = {};
+      map[url] = this.siteSettings.logo_small
+      return map;
     } else {
       console.log(44);
       return this.args.category.uploaded_logo; // If no dark mode logo is uploaded, use the normal logo

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -52,14 +52,14 @@ export default class CategoryHeader extends Component {
   get logoImg() {
     if (settings.show_category_logo && this.args.category.uploaded_logo) {
       console.log(this.args.category.uploaded_logo.url);
-      return this.args.category.uploaded_logo.url;
+      return this.args.category.uploaded_logo;
     } else if (
       settings.show_category_logo &&
       settings.show_parent_category_logo &&
       this.args.category.parentCategory &&
       this.args.category.parentCategory.uploaded_logo
     ) {
-      return this.args.category.parentCategory.uploaded_logo.url;
+      return this.args.category.parentCategory.uploaded_logo;
     } else if (settings.show_site_logo && this.siteSettings.logo_small) {
       return this.siteSettings.logo_small;
     } else {
@@ -70,14 +70,14 @@ export default class CategoryHeader extends Component {
   get darkLogoImg() {
     if (settings.show_dark_mode_category_logo && this.args.category.uploaded_logo_dark.url) {
       console.log(this.args.category.uploaded_logo_dark.url);
-      return this.args.category.uploaded_logo_dark.url;
+      return this.args.category.uploaded_logo_dark;
     } else if (
       settings.show_dark_mode_category_logo &&
       settings.show_parent_category_dark_mode_logo &&
       this.args.category.parentCategory &&
       this.args.category.parentCategory.uploaded_logo_dark
     ) {
-      return this.args.category.parentCategory.uploaded_logo_dark.url;
+      return this.args.category.parentCategory.uploaded_logo_dark;
     } else if (settings.show_site_logo && this.siteSettings.logo_small) {
       return this.siteSettings.logo_small;
     } else {

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -3,7 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 
-import LightDarkImg from "discourse/components/light-dark-img";
+import LightDarkImg from "light-dark-img";
 import { ajax } from "discourse/lib/ajax";
 import icon from "discourse/helpers/d-icon";
 

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -7,7 +7,7 @@ import LightDarkImg from "discourse/components/light-dark-img";
 import { ajax } from "discourse/lib/ajax";
 import icon from "discourse/helpers/d-icon";
 
-import { not } from "truth-helpers";
+import { or, not } from "truth-helpers";
 
 export default class CategoryHeader extends Component {
   @service siteSettings;
@@ -64,6 +64,23 @@ export default class CategoryHeader extends Component {
     } else {
       return false;
     }
+  }
+
+  get darkLogoImg() {
+    if (settings.show_dark_mode_category_logo && this.args.category.uploaded_logo_dark.url) {
+      return this.args.category.uploaded_logo.url;
+    } else if (
+      settings.show_dark_mode_category_logo &&
+      settings.show_parent_category_dark_mode_logo &&
+      this.args.category.parentCategory &&
+      this.args.category.parentCategory.uploaded_logo_dark
+    ) {
+      return this.args.category.parentCategory.uploaded_logo_dark.url;
+    } else if (settings.show_site_logo && this.siteSettings.logo_small) {
+      return this.siteSettings.logo_small;
+    } else {
+      return this.args.category.uploaded_logo; // If no dark mode logo is uploaded, use the normal logo
+    } 
   }
 
   get ifParentProtected() {
@@ -172,9 +189,12 @@ export default class CategoryHeader extends Component {
         style={{this.getHeaderStyle}}
       >
         <div class="category-title-contents">
-          {{#if this.logoImg}}
+          {{#if (or this.logoImg this.darkLogoImg)}}
             <div class="category-logo aspect-image">
-              <img src={{this.logoImg}} />
+              <LightDarkImg
+                @lightImg={{this.logoImg}}
+                @darkImg={{this.darkLogoImg}}
+              />
             </div>
           {{/if}}
           <div class="category-title-name" style={{if (not (this.logoImg)) "padding: 0 !important;"}}>

--- a/javascripts/discourse/components/category-header.gjs
+++ b/javascripts/discourse/components/category-header.gjs
@@ -68,7 +68,7 @@ export default class CategoryHeader extends Component {
   }
 
   get darkLogoImg() {
-    if (settings.show_dark_mode_category_logo && this.args.category.uploaded_logo_dark.url) {
+    if (settings.show_dark_mode_category_logo && this.args.category.uploaded_logo_dark) {
       console.log(this.args.category.uploaded_logo_dark.url);
       return this.args.category.uploaded_logo_dark;
     } else if (

--- a/javascripts/discourse/components/light-dark-img.gjs
+++ b/javascripts/discourse/components/light-dark-img.gjs
@@ -1,0 +1,67 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+import CdnImg from "discourse/components/cdn-img";
+import { getURLWithCDN } from "discourse/lib/get-url";
+
+export default class LightDarkImg extends Component {
+  @service session;
+  @service interfaceColor;
+
+  get isDarkImageAvailable() {
+    return (
+      this.args.lightImg?.url && // the light image must be present
+      this.args.darkImg?.url &&
+      (this.session.defaultColorSchemeIsDark || this.session.darkModeAvailable)
+    );
+  }
+
+  get defaultImg() {
+    // use dark logo by default in edge case
+    // when scheme is dark and dark logo is present
+    if (this.session.defaultColorSchemeIsDark && this.args.darkImg) {
+      return this.args.darkImg;
+    }
+
+    return this.args.lightImg;
+  }
+
+  get darkImgCdnSrc() {
+    return getURLWithCDN(this.args.darkImg.url);
+  }
+
+  get darkMediaQuery() {
+    if (this.interfaceColor.darkModeForced) {
+      return "all";
+    } else if (this.interfaceColor.lightModeForced) {
+      return "none";
+    } else {
+      return "(prefers-color-scheme: dark)";
+    }
+  }
+
+  <template>
+    {{#if this.isDarkImageAvailable}}
+      <picture>
+        <source
+          srcset={{this.darkImgCdnSrc}}
+          width={{@darkImg.width}}
+          height={{@darkImg.height}}
+          media={{this.darkMediaQuery}}
+        />
+        <CdnImg
+          ...attributes
+          @src={{this.defaultImg.url}}
+          @width={{this.defaultImg.width}}
+          @height={{this.defaultImg.height}}
+        />
+      </picture>
+    {{else if @lightImg.url}}
+      <CdnImg
+        ...attributes
+        @src={{@lightImg.url}}
+        @width={{@lightImg.width}}
+        @height={{@lightImg.height}}
+      />
+    {{/if}}
+  </template>
+}

--- a/javascripts/discourse/components/light-dark-img.gjs
+++ b/javascripts/discourse/components/light-dark-img.gjs
@@ -8,6 +8,10 @@ export default class LightDarkImg extends Component {
   @service interfaceColor;
 
   get isDarkImageAvailable() {
+    console.log(this.args.lightImg?.url);
+    console.log(this.args.darkImg?.url);
+    console.log(this.session.defaultColorSchemeIsDark);
+    console.log(this.session.darkModeAvailable);
     return (
       this.args.lightImg?.url && // the light image must be present
       this.args.darkImg?.url &&
@@ -26,10 +30,13 @@ export default class LightDarkImg extends Component {
   }
 
   get darkImgCdnSrc() {
+    console.log("CDN: " + getURLWithCDN(this.args.darkImg.url));
     return getURLWithCDN(this.args.darkImg.url);
   }
 
   get darkMediaQuery() {
+    console.log(this.interfaceColor.lightModeForced);
+    console.log(this.interfaceColor.darkModeForced);
     if (this.interfaceColor.darkModeForced) {
       return "all";
     } else if (this.interfaceColor.lightModeForced) {

--- a/settings.yml
+++ b/settings.yml
@@ -67,9 +67,9 @@ show_parent_category_logo:
   default: true
   description: 'Show the parent category logo when a subcategory logo is not set'
 
-show_dar_mode_parent_category_logo:
+show_dark_mode_parent_category_logo:
   type: bool
-  default: true
+  default: false
   description: "Show the parent category's dark mode logo when a subcategory logo is not set."
   
 show_site_logo:

--- a/settings.yml
+++ b/settings.yml
@@ -60,12 +60,17 @@ show_category_logo:
 show_dark_mode_category_logo:
   type: bool
   default: false
-  description: 'Show the dark mode category logo instead of the normal category logo. If checked, it will override the `show_category_logo` setting above.'
+  description: 'Show the dark mode category logo instead of the normal category logo.'
   
 show_parent_category_logo:
   type: bool
   default: true
-  description: 'Show the parent category logo when a subcategory logo is not set'    
+  description: 'Show the parent category logo when a subcategory logo is not set'
+
+show_dar_mode_parent_category_logo:
+  type: bool
+  default: true
+  description: "Show the parent category's dark mode logo when a subcategory logo is not set."
   
 show_site_logo:
   type: bool

--- a/settings.yml
+++ b/settings.yml
@@ -56,6 +56,11 @@ show_category_logo:
   type: bool
   default: true
   description: 'Show the category logo image within the header'
+
+show_dark_mode_category_logo:
+  type: bool
+  default: false
+  description: 'Show the dark mode category logo instead of the normal category logo. If checked, it will override the `show_category_logo` setting above.'
   
 show_parent_category_logo:
   type: bool


### PR DESCRIPTION
This PR adds 2 new settings, `show_dark_mode_category_logo` and `show_dark_mode_parent_category_logo` to support dark mode category logos. If a category has dark mode logos uploaded, it will use that instead of the normal category logo. If the latter setting is ticked, it will use the parent's dark mode category logo if the category has no logo uploaded.